### PR TITLE
Add release folder and template

### DIFF
--- a/releases/template/README.md
+++ b/releases/template/README.md
@@ -1,12 +1,17 @@
 # Device Name &bull; Operating System &bull; Identifier
 
-Duplicate the template directory and name it after your release.
-Releases describe a known good configuration. Find the latest commit in Nexmon_CSI master which works reliably on your setup and enter it's details here.
+* Duplicate the template directory and name it after your release.
+* Release describes a known good configuration. Find the latest commit in Nexmon_CSI master which works reliably on your setup and enter it's details here.
+* For example, Commit b52fca works reliably on Raspberry Pi 3B+ running Raspbian Buster with kernel v4.19.97. So I should add that commit hash and it's date: January 30 2020 here.
 
-For example, Commit b52fca3abc18715d6d12692e531164b5d62a78fd works reliably on Raspberry Pi 3B+ running Raspbian Buster with kernel v4.19.97. So I should add that commit hash and it's date: January 30 2020 here.
-
-Commit: commit hash
-Date: Date of commit
+|||
+|---|---|
+|Device|Device Name|
+|Operating System|OS Name|
+|Kernel Version|Remove if not applicable|  
+|Commit|[<commit hash>](link to commit)|
+|Nexmon Commit|[<commit hash>](link to commit)|
+|Date| Date for Nexmon_CSI commit|
 
 
 ## Installation instructions

--- a/releases/template/README.md
+++ b/releases/template/README.md
@@ -1,0 +1,29 @@
+# Device Name &bull; Operating System &bull; Identifier
+
+Duplicate the template directory and name it after your release.
+Releases describe a known good configuration. Find the latest commit in Nexmon_CSI master which works reliably on your setup and enter it's details here.
+
+For example, Commit b52fca3abc18715d6d12692e531164b5d62a78fd works reliably on Raspberry Pi 3B+ running Raspbian Buster with kernel v4.19.97. So I should add that commit hash and it's date: January 30 2020 here.
+
+Commit: commit hash
+Date: Date of commit
+
+
+## Installation instructions
+
+Add installation instructions here. You may use scripts to make installation easy and reliable. If you do, put them in the same folder.
+
+After cloning Nexmon or Nexmon_CSI `git checkout` to a specific version so that the installation is deterministic.
+
+## Usage
+
+Add usage instructions here. 
+
+## Known issues
+
+Add any known issues here.
+
+## Notes
+
+Add any additional notes here.
+


### PR DESCRIPTION
See the [rendered](https://github.com/zeroby0/nexmon_csi/tree/releases/releases/template) version.

Adds `releases` folder and a template Readme file.

See https://github.com/seemoo-lab/nexmon_csi/issues/120 for RFC.