### PR TITLE
Release pi3Bplus-buster-4.19.97

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ The following steps will get you started on Xubuntu 16.04 LTS:
 
 ## bcm43455c0
 
+Releases provide configurations known to work. Select the release that suits you and follow it's instructions to get started. General installation instructions are given further below.
+
+|Release|Device|OS|Kernel|
+|---|---|---|---|
+|[pi3Bplus-buster-4.19.97](./releases/pi3Bplus-buster-4.19.97/README.md)|Raspberry Pi 3B+|[Raspbian Buster Lite 2020-02-13](https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/)|v4.19.97|
+
 On your Raspberry Pi 3B+/4 running Raspbian/Raspberry Pi OS with kernel 4.19 or 5.4 run the following:
 1. Make sure the following commands are executed as root: `sudo su`
 2. Upgrade your Raspbian installation: `apt-get update && apt-get upgrade`

--- a/releases/pi3Bplus-buster-4.19.97/README.md
+++ b/releases/pi3Bplus-buster-4.19.97/README.md
@@ -1,12 +1,15 @@
-# Pi 3B+ &bull; Raspbian Buster &bull; Kernel v4.19.97
+# Pi 3B+ and 4B &bull; Raspbian Buster &bull; Kernel v4.19.97
 
 |||
 |---|---|
-|Device | Raspberry Pi 3B+|
+|Device | Raspberry Pi 3B+ and 4B|
 |Raspbian | [Raspbian Buster Lite 2020-02-13](https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/)|
 |Commit | [b52fca](https://github.com/seemoo-lab/nexmon_csi/commit/b52fca3abc18715d6d12692e531164b5d62a78fd)|
 |Nexmon Commit | [f9db9a](https://github.com/seemoo-lab/nexmon/commit/f9db9abcac8f40a7f8a8408429e34e1c51f33c97)|
 |Date | January 30, 2020|
+
+ **Note**: [Release pi-buster-4.19.97-plus](https://github.com/zeroby0/nexmon_csi/tree/release-pi-buster-4.19.97-plus/releases/pi-buster-4.19.97-plus) has unmerged code to add stability and more features.
+
 
 ## Installation
 
@@ -30,7 +33,7 @@ Get Kernel Headers
 
 Install Nexmon_CSI
 * `sudo su`
-* `wget https://raw.githubusercontent.com/seemoo-lab/nexmon_csi/master/releases/pi3Bplus-buster-4.19.97/install.sh -O install.sh`
+* `wget https://raw.githubusercontent.com/zeroby0/nexmon_csi/master/releases/pi3Bplus-buster-4.19.97/install.sh -O install.sh`
 * `tmux new -c /home/pi -s nexmon 'bash install.sh | tee output.log'`
 
 Your installation will happen in this tmux session. The right bottom corner will show the step running. Use `ctrl-b d` to detach, and `tmux attach-session -t nexmon` to re-attach.
@@ -52,4 +55,4 @@ Collect CSI by listening on UDP socket 5500, e.g. by using tcpdump: `tcpdump -i 
 
 ## Known issues
 * CSI collection may stop after changing parameters several times.
-* CSI collection may stop after collecting several samples.  If you have this problem, see https://github.com/seemoo-lab/nexmon_csi/pull/46
+* CSI collection may stop after collecting several samples.  If you have this problem, see [release pi-buster-4.19.97-plus](https://github.com/zeroby0/nexmon_csi/tree/release-pi-buster-4.19.97-plus/releases/pi-buster-4.19.97-plus)

--- a/releases/pi3Bplus-buster-4.19.97/README.md
+++ b/releases/pi3Bplus-buster-4.19.97/README.md
@@ -1,0 +1,55 @@
+# Pi 3B+ &bull; Raspbian Buster &bull; Kernel v4.19.97
+
+|||
+|---|---|
+|Device | Raspberry Pi 3B+|
+|Raspbian | [Raspbian Buster Lite 2020-02-13](https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/)|
+|Commit | [b52fca](https://github.com/seemoo-lab/nexmon_csi/commit/b52fca3abc18715d6d12692e531164b5d62a78fd)|
+|Nexmon Commit | [f9db9a](https://github.com/seemoo-lab/nexmon/commit/f9db9abcac8f40a7f8a8408429e34e1c51f33c97)|
+|Date | January 30, 2020|
+
+## Installation
+
+* Burn [Raspbian Buster Lite 2020-02-13](https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/) onto an empty SD card. You can use [Etcher](https://www.balena.io/etcher/).
+* [Create an empty file called `ssh`](https://www.raspberrypi.org/documentation/remote-access/ssh/), without any extension, on the boot partition of the SD card.
+* [SSH](https://www.raspberrypi.org/documentation/remote-access/ssh/) into the Pi.
+* With `sudo raspi-config`, set WiFi Country, Time Zone, and then Expand File System.
+* Reboot when asked to.
+
+Install dependencies. Do **not** run `apt upgrade`.
+
+* `sudo apt update`
+* `sudo apt install git libgmp3-dev gawk qpdf bc bison flex libssl-dev make automake texinfo libtool-bin tcpdump tmux libncurses5-dev`
+* `sudo reboot`
+
+Get Kernel Headers
+
+* `sudo wget https://raw.githubusercontent.com/RPi-Distro/rpi-source/master/rpi-source -O /usr/local/bin/rpi-source && sudo chmod +x /usr/local/bin/rpi-source && /usr/local/bin/rpi-source -q --tag-update`
+* `rpi-source`
+* `sudo reboot`
+
+Install Nexmon_CSI
+* `sudo su`
+* `wget https://raw.githubusercontent.com/seemoo-lab/nexmon_csi/master/releases/pi3Bplus-buster-4.19.97/install.sh -O install.sh`
+* `tmux new -c /home/pi -s nexmon 'bash install.sh | tee output.log'`
+
+Your installation will happen in this tmux session. The right bottom corner will show the step running. Use `ctrl-b d` to detach, and `tmux attach-session -t nexmon` to re-attach.
+
+## Usage
+
+1. Use `makecsiparams` to generate a base64 encoded parameter string which is used to configure the extractor.
+    ```
+    mcp -c 157/80 -C 1 -N 1
+    m+IBEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+    ```
+    `makecsiparams` supports several other features like filtering data by Mac IDs or by first byte. Run `mcp -h` to see all available options.
+2. `ifconfig wlan0 up`
+3. `nexutil -Iwlan0 -s500 -b -l34 -vm+IBEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==`
+4. `iw dev wlan0 interface add mon0 type monitor`
+5. `ip link set mon0 up`
+
+Collect CSI by listening on UDP socket 5500, e.g. by using tcpdump: `tcpdump -i wlan0 dst port 5500`. There will be one UDP packet per configured core and spatial stream for each incoming frame matching the configured filter.
+
+## Known issues
+* CSI collection may stop after changing parameters several times.
+* CSI collection may stop after collecting several samples.  If you have this problem, see https://github.com/seemoo-lab/nexmon_csi/pull/46

--- a/releases/pi3Bplus-buster-4.19.97/install.sh
+++ b/releases/pi3Bplus-buster-4.19.97/install.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+function setStatus () {
+  if { [ "$TERM" = "screen" ] && [ -n "$TMUX" ]; } then
+    tmux set status-right "Status: $1"
+  else
+    echo "Status: $1"
+  fi
+}
+
+setStatus "Removing wpasupplicant"
+apt remove wpasupplicant -y
+echo "denyinterfaces wlan0" >> /etc/dhcpcd.conf
+
+setStatus "Downloading Nexmon"
+git clone https://github.com/seemoo-lab/nexmon.git
+cd nexmon
+git checkout f9db9abcac8f40a7f8a8408429e34e1c51f33c97
+NEXDIR=$(pwd)
+
+setStatus "Building libISL"
+cd $NEXDIR/buildtools/isl-0.10
+autoreconf -f -i
+./configure
+make
+make install
+ln -s /usr/local/lib/libisl.so /usr/lib/arm-linux-gnueabihf/libisl.so.10
+
+setStatus "Building libMPFR"
+cd $NEXDIR/buildtools/mpfr-3.1.4
+autoreconf -f -i
+./configure
+make
+make install
+ln -s /usr/local/lib/libmpfr.so /usr/lib/arm-linux-gnueabihf/libmpfr.so.4
+
+setStatus "Setting up Build Environment"
+cd $NEXDIR
+source setup_env.sh
+make
+
+setStatus "Downloading Nexmon_CSI"
+cd $NEXDIR/patches/bcm43455c0/7_45_189/
+git clone https://github.com/seemoo-lab/nexmon_csi.git
+
+setStatus "Building and installing Nexmon_CSI"
+cd nexmon_csi
+git checkout b52fca3abc18715d6d12692e531164b5d62a78fd
+make install-firmware
+
+setStatus "Installing makecsiparams"
+cd utils/makecsiparams
+make
+ln -s $PWD/makecsiparams /usr/local/bin/mcp
+
+setStatus "Installing nexutil"
+cd $NEXDIR/utilities/nexutil
+make
+make install
+
+setStatus "Setting up Persistance"
+cd $NEXDIR/patches/bcm43455c0/7_45_189/nexmon_csi/
+cd brcmfmac_4.19.y-nexmon
+mv $(modinfo brcmfmac -n) ./brcmfmac.ko.orig
+cp ./brcmfmac.ko $(modinfo brcmfmac -n)
+depmod -a
+
+touch /home/pi/COMPLETED
+setStatus "Completed"

--- a/releases/template/README.md
+++ b/releases/template/README.md
@@ -1,12 +1,17 @@
 # Device Name &bull; Operating System &bull; Identifier
 
-Duplicate the template directory and name it after your release.
-Releases describe a known good configuration. Find the latest commit in Nexmon_CSI master which works reliably on your setup and enter it's details here.
+* Duplicate the template directory and name it after your release.
+* Release describes a known good configuration. Find the latest commit in Nexmon_CSI master which works reliably on your setup and enter it's details here.
+* For example, Commit b52fca works reliably on Raspberry Pi 3B+ running Raspbian Buster with kernel v4.19.97. So I should add that commit hash and it's date: January 30 2020 here.
 
-For example, Commit b52fca3abc18715d6d12692e531164b5d62a78fd works reliably on Raspberry Pi 3B+ running Raspbian Buster with kernel v4.19.97. So I should add that commit hash and it's date: January 30 2020 here.
-
-Commit: commit hash
-Date: Date of commit
+|||
+|---|---|
+|Device|Device Name|
+|Operating System|OS Name|
+|Kernel Version|Remove if not applicable|  
+|Commit|[<commit hash>](link to commit)|
+|Nexmon Commit|[<commit hash>](link to commit)|
+|Date| Date for Nexmon_CSI commit|
 
 
 ## Installation instructions

--- a/releases/template/README.md
+++ b/releases/template/README.md
@@ -1,0 +1,29 @@
+# Device Name &bull; Operating System &bull; Identifier
+
+Duplicate the template directory and name it after your release.
+Releases describe a known good configuration. Find the latest commit in Nexmon_CSI master which works reliably on your setup and enter it's details here.
+
+For example, Commit b52fca3abc18715d6d12692e531164b5d62a78fd works reliably on Raspberry Pi 3B+ running Raspbian Buster with kernel v4.19.97. So I should add that commit hash and it's date: January 30 2020 here.
+
+Commit: commit hash
+Date: Date of commit
+
+
+## Installation instructions
+
+Add installation instructions here. You may use scripts to make installation easy and reliable. If you do, put them in the same folder.
+
+After cloning Nexmon or Nexmon_CSI `git checkout` to a specific version so that the installation is deterministic.
+
+## Usage
+
+Add usage instructions here. 
+
+## Known issues
+
+Add any known issues here.
+
+## Notes
+
+Add any additional notes here.
+


### PR DESCRIPTION
# Pi 3B+ &bull; Raspbian Buster &bull; Kernel v4.19.97

See the [rendered](https://github.com/zeroby0/nexmon_csi/tree/release-pi3Bplus-buster-4.19.97/releases/pi3Bplus-buster-4.19.97) version here.

**Note**: If you're planning to install nexmon_csi, you should use [Release pi-buster-4.19.97-plus](https://github.com/zeroby0/nexmon_csi/blob/release-pi-buster-4.19.97-plus/releases/pi-buster-4.19.97-plus/README.md) instead of the rendered version of this pull request.

|||
|---|---|
|Device | Raspberry Pi 3B+|
|Raspbian | [Raspbian Buster Lite 2020-02-13](https://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/)|
|Commit | [b52fca](https://github.com/seemoo-lab/nexmon_csi/commit/b52fca3abc18715d6d12692e531164b5d62a78fd)|
|Nexmon Commit | [f9db9a](https://github.com/seemoo-lab/nexmon/commit/f9db9abcac8f40a7f8a8408429e34e1c51f33c97)|
|Date | January 30, 2020|

When Github Discussions is released, we will create a thread dedicated to this release. Till then, please comment below if you have any questions or suggestions.

See #120 for Releases RFC.

